### PR TITLE
Fix line break rendering for player messages in editor chat

### DIFF
--- a/www/editor.html
+++ b/www/editor.html
@@ -222,14 +222,13 @@ function loadMessages() {
     if (d.messages) {
       var bubbles = list.querySelectorAll('.editor-msg-bubble');
       d.messages.forEach(function(m, i) {
+        var escaped = esc(m.content);
         if (m.role === 'player') {
-          var escaped = m.content.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
           bubbles[i].innerHTML = '<p>' + escaped.replace(/\n\n/g, '</p><p>').replace(/\n/g, '<br>') + '</p>';
         }
         else {
           // Convert markdown to HTML for editor messages
-          var html = m.content
-            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')  // escape HTML first
+          var html = escaped
             .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')  // **bold**
             .replace(/\*([^*]+)\*/g, '<em>$1</em>')  // *italic*
             .replace(/\n\n/g, '</p><p>')  // double newline = paragraph


### PR DESCRIPTION
Player messages now convert newlines to `<br>` / paragraph breaks (previously used textContent which collapsed whitespace). Editor messages already handled this as part of their markdown-to-HTML rendering.

Tested locally with a little mock server thing — didn't include that in this PR but here it is in a separate branch if someone wants to steal it for something: https://github.com/peterjmag/freeciv.andrewmcgrath.info/commit/d3ceb212f0e36828af122b814fb1ac25701323b1

**EDIT:** Oops just realized the code in that first commit was generated by Sonnet 4.6. I switched over to Opus 4.6 before committing, but Opus hadn't taken a pass at the code yet — just did that now and pushed up the resulting commit: https://github.com/ndroo/freeciv.andrewmcgrath.info/pull/2/commits/c6874b7c4bc100d69db77e9b424198c38ad09f3b. If you're cool with the final diff, I'd recommend squash merging, or I can squash + force-push or something 🤝 

| Before | After |
|--------|--------|
| <img width="520" height="669" alt="localhost_8888_editor html (1)" src="https://github.com/user-attachments/assets/e94b5f96-84ce-4871-922c-62229fcd0b8e" /> | <img width="520" height="669" alt="localhost_8888_editor html" src="https://github.com/user-attachments/assets/d3b0d02b-f65c-4bd7-a1a6-2edde5790638" /> | 